### PR TITLE
Fixed PUT gift

### DIFF
--- a/giftcompare/gifts/views.py
+++ b/giftcompare/gifts/views.py
@@ -32,7 +32,7 @@ class GiftDetail(APIView):
         
     def put(self, request, pk):
         gift = self.get_object(pk)
-        serializer = GiftSerializer(gift, data=request.data)
+        serializer = GiftSerializer(instance = gift, data = request.data, partial = True)
         if serializer.is_valid():
             serializer.save()
             return Response(serializer.data)


### PR DESCRIPTION
The update gift method was not allowing me to update only one field as supposed to but it was erroring saying that all the other fields were required.

This was only one line of code - apologies for not seeing when reviewing the previous PR.

eg: I am now able to just change the name property - changed from 'test01' to 'test':

![image](https://github.com/SheCodesAus/2024_first_class_constructors_back_end/assets/115125025/1c6823c3-0ca1-482d-b94d-c69c8dbd5e6f)

![image](https://github.com/SheCodesAus/2024_first_class_constructors_back_end/assets/115125025/a303bce9-3b3d-41ad-a7a1-e8843bdff744)

![image](https://github.com/SheCodesAus/2024_first_class_constructors_back_end/assets/115125025/74345bd3-dbf2-4bcf-9045-84dae6ab7bae)

